### PR TITLE
Prefer _options over _attributes

### DIFF
--- a/app/components/flowbite/input/field.rb
+++ b/app/components/flowbite/input/field.rb
@@ -24,7 +24,7 @@ module Flowbite
         ERROR = :error
       ].freeze
 
-      attr_reader :input_attributes, :size, :style
+      attr_reader :input_options, :size, :style
 
       class << self
         def classes(size: :default, state: :default, style: :default)
@@ -57,11 +57,11 @@ module Flowbite
         # rubocop:enable Layout/LineLength
       end
 
-      def initialize(attribute:, form:, disabled: false, input_attributes: {}, size: :default)
+      def initialize(attribute:, form:, disabled: false, input_options: {}, size: :default)
         @attribute = attribute
         @disabled = disabled
         @form = form
-        @input_attributes = input_attributes
+        @input_options = input_options
         @object = form.object
         @size = size
       end
@@ -101,7 +101,7 @@ module Flowbite
         {
           class: classes,
           disabled: disabled?
-        }.merge(input_attributes)
+        }.merge(input_options)
       end
 
       private

--- a/app/components/flowbite/input/label.rb
+++ b/app/components/flowbite/input/label.rb
@@ -39,12 +39,12 @@ module Flowbite
         @object.errors.include?(@attribute.intern)
       end
 
-      def initialize(attribute:, form:, disabled: false, label_attributes: {}, options: {})
+      def initialize(attribute:, form:, disabled: false, label_options: {}, options: {})
         @attribute = attribute
         @disabled = disabled
         @form = form
         @object = form.object
-        @label_attributes = label_attributes
+        @label_options = label_options
         @options = options
       end
 
@@ -76,7 +76,7 @@ module Flowbite
       def options
         {
           class: classes
-        }.merge(@label_attributes).merge(@options)
+        }.merge(@label_options).merge(@options)
       end
     end
   end

--- a/app/components/flowbite/input/select.rb
+++ b/app/components/flowbite/input/select.rb
@@ -14,8 +14,8 @@ module Flowbite
         lg: ["px-4", "py-3", "text-base"]
       }.freeze
 
-      def initialize(form:, attribute:, collection: [], disabled: false, input_attributes: {}, size: :default)
-        super(form: form, attribute: attribute, disabled: disabled, input_attributes: input_attributes, size: size)
+      def initialize(form:, attribute:, collection: [], disabled: false, input_options: {}, size: :default)
+        super(form: form, attribute: attribute, disabled: disabled, input_options: input_options, size: size)
         @collection = collection
       end
 
@@ -42,7 +42,7 @@ module Flowbite
         {
           class: classes,
           disabled: disabled?
-        }.merge(@input_attributes)
+        }.merge(@input_options)
       end
 
       # Returns the options argument for the select method

--- a/app/components/flowbite/input_field.rb
+++ b/app/components/flowbite/input_field.rb
@@ -34,7 +34,7 @@ module Flowbite
   # Flowbite::Input::Label, see that for details. Can contain:
   # - `content`: The content of the label. If not provided, the label will
   #   default to the attribute name.
-  # - `label_attributes`: A hash of additional HTML attributes to apply to the
+  # - `label_options`: A hash of additional HTML attributes to apply to the
   #   label element.
   # - `options`: A hash of additional options to pass to the label component.
   #   This can be used to set the class, for example.
@@ -42,7 +42,7 @@ module Flowbite
   # @param disabled [Boolean] Whether the input field should be disabled.
   # Defaults to `false`.
   #
-  # @param input_attributes [Hash] Additional HTML attributes to pass to the
+  # @param input_options [Hash] Additional HTML attributes to pass to the
   # input element.
   #
   # @param size [Symbol] The size of the input field. Can be one of `:sm`,
@@ -69,12 +69,12 @@ module Flowbite
       @object.errors[@attribute] || []
     end
 
-    def initialize(attribute:, form:, disabled: false, hint: nil, input_attributes: {}, label: {}, size: :default)
+    def initialize(attribute:, form:, disabled: false, hint: nil, input_options: {}, label: {}, size: :default)
       @attribute = attribute
       @disabled = disabled
       @form = form
       @hint = hint
-      @input_attributes = input_attributes
+      @input_options = input_options
       @label = label
       @object = form.object
       @size = size
@@ -102,7 +102,7 @@ module Flowbite
         form: @form,
         attribute: @attribute,
         disabled: @disabled,
-        input_attributes: default_input_attributes.merge(@input_attributes),
+        input_options: default_input_options.merge(@input_options),
         size: @size
       ))
     end
@@ -111,9 +111,9 @@ module Flowbite
 
     # Returns a Hash with the default attributes to apply to the input element.
     #
-    # The default attributes can be overriden by passing the `input_attributes`
+    # The default attributes can be overriden by passing the `input_options`
     # argument to the constructor.
-    def default_input_attributes
+    def default_input_options
       if hint?
         {
           "aria-describedby": id_for_hint_element

--- a/app/components/flowbite/input_field/checkbox.rb
+++ b/app/components/flowbite/input_field/checkbox.rb
@@ -34,7 +34,7 @@ module Flowbite
           Flowbite::Input::Label.new(
             attribute: @attribute,
             form: @form,
-            label_attributes: {
+            label_options: {
               class: label_classes
             }
           )

--- a/app/components/flowbite/input_field/select.rb
+++ b/app/components/flowbite/input_field/select.rb
@@ -3,8 +3,8 @@
 module Flowbite
   class InputField
     class Select < InputField
-      def initialize(attribute:, form:, collection: [], hint: nil, input_attributes: {}, size: :default)
-        super(attribute: attribute, form: form, hint: hint, input_attributes: input_attributes, size: size)
+      def initialize(attribute:, form:, collection: [], hint: nil, input_options: {}, size: :default)
+        super(attribute: attribute, form: form, hint: hint, input_options: input_options, size: size)
         @collection = collection
       end
 
@@ -14,7 +14,7 @@ module Flowbite
             attribute: @attribute,
             collection: @collection,
             form: @form,
-            input_attributes: @input_attributes,
+            input_options: @input_options,
             size: @size
           )
         )

--- a/test/components/flowbite/input_field_test.rb
+++ b/test/components/flowbite/input_field_test.rb
@@ -49,7 +49,7 @@ class Flowbite::InputFieldTest < Minitest::Test
 
   def test_renders_a_label_with_specified_attributes
     render_inline(
-      Flowbite::InputField.new(form: @form, attribute: :title, label: {label_attributes: {class: "custom-label"}})
+      Flowbite::InputField.new(form: @form, attribute: :title, label: {label_options: {class: "custom-label"}})
     )
 
     assert_selector("label[for='book_title'].custom-label")
@@ -85,8 +85,8 @@ class Flowbite::InputFieldTest < Minitest::Test
     assert_text("Block with a full component")
   end
 
-  def test_passes_input_attributes_to_input_element
-    render_inline(Flowbite::InputField.new(form: @form, attribute: :title, input_attributes: {placeholder: "Enter title"}))
+  def test_passes_input_options_to_input_element
+    render_inline(Flowbite::InputField.new(form: @form, attribute: :title, input_options: {placeholder: "Enter title"}))
 
     assert_component_rendered
     assert_selector("input[type='text'][placeholder='Enter title']")
@@ -98,8 +98,8 @@ class Flowbite::InputFieldTest < Minitest::Test
     assert_selector("select.text-base.px-4.py-3")
   end
 
-  def test_passes_input_attributes_to_select_element
-    render_inline(Flowbite::InputField::Select.new(form: @form, attribute: :state, collection: ["read", "unread"], input_attributes: {"data-key": "state-select"}))
+  def test_passes_input_options_to_select_element
+    render_inline(Flowbite::InputField::Select.new(form: @form, attribute: :state, collection: ["read", "unread"], input_options: {"data-key": "state-select"}))
 
     assert_selector("select[data-key='state-select']")
   end

--- a/test/components/input/checkbox_test.rb
+++ b/test/components/input/checkbox_test.rb
@@ -44,13 +44,13 @@ class Flowbite::Input::CheckboxTest < Minitest::Test
   end
 
   def test_adds_attributes_to_input
-    render_inline(Flowbite::Input::Checkbox.new(form: @form, attribute: :subscribed, input_attributes: {"data-controller": "checkbox"}))
+    render_inline(Flowbite::Input::Checkbox.new(form: @form, attribute: :subscribed, input_options: {"data-controller": "checkbox"}))
 
     assert_selector("input[name='user[subscribed]'][data-controller='checkbox']")
   end
 
   def test_renders_a_hidden_input_for_the_unchecked_case
-    render_inline(Flowbite::Input::Checkbox.new(form: @form, attribute: :subscribed, input_attributes: {"data-controller": "checkbox"}))
+    render_inline(Flowbite::Input::Checkbox.new(form: @form, attribute: :subscribed, input_options: {"data-controller": "checkbox"}))
 
     assert_selector("input[type='hidden'][name='user[subscribed]'][value='0']", visible: false)
   end

--- a/test/components/input/date_test.rb
+++ b/test/components/input/date_test.rb
@@ -49,7 +49,7 @@ class Flowbite::Input::DateTest < Minitest::Test
   end
 
   def test_adds_attributes_to_input
-    render_inline(Flowbite::Input::Date.new(form: @form, attribute: :published_at, input_attributes: {placeholder: "Enter publish date"}))
+    render_inline(Flowbite::Input::Date.new(form: @form, attribute: :published_at, input_options: {placeholder: "Enter publish date"}))
 
     assert_selector("input[name='book[published_at]'][placeholder='Enter publish date']")
   end

--- a/test/components/input/email_test.rb
+++ b/test/components/input/email_test.rb
@@ -49,7 +49,7 @@ class Flowbite::Input::EmailTest < Minitest::Test
   end
 
   def test_adds_attributes_to_input
-    render_inline(Flowbite::Input::Email.new(form: @form, attribute: :email, input_attributes: {placeholder: "Enter email address"}))
+    render_inline(Flowbite::Input::Email.new(form: @form, attribute: :email, input_options: {placeholder: "Enter email address"}))
 
     assert_selector("input[name='user[email]'][placeholder='Enter email address']")
   end

--- a/test/components/input/field_test.rb
+++ b/test/components/input/field_test.rb
@@ -55,7 +55,7 @@ class Flowbite::Input::FieldTest < Minitest::Test
   end
 
   def test_adds_attributes_to_input
-    render_inline(Flowbite::Input::Field.new(form: @form, attribute: :title, input_attributes: {placeholder: "Enter title"}))
+    render_inline(Flowbite::Input::Field.new(form: @form, attribute: :title, input_options: {placeholder: "Enter title"}))
 
     assert_component_rendered
     assert_selector("input[name='book[title]'][placeholder='Enter title']")

--- a/test/components/input/label_test.rb
+++ b/test/components/input/label_test.rb
@@ -40,7 +40,7 @@ class Flowbite::Input::LabelTest < Minitest::Test
   end
 
   def test_sets_class_attribute
-    render_inline(Flowbite::Input::Label.new(form: @form, attribute: :title, label_attributes: {class: "toggle"}))
+    render_inline(Flowbite::Input::Label.new(form: @form, attribute: :title, label_options: {class: "toggle"}))
 
     assert_selector("label.toggle")
   end

--- a/test/components/input/number_test.rb
+++ b/test/components/input/number_test.rb
@@ -49,7 +49,7 @@ class Flowbite::Input::NumberTest < Minitest::Test
   end
 
   def test_adds_attributes_to_input
-    render_inline(Flowbite::Input::Number.new(form: @form, attribute: :price, input_attributes: {placeholder: "Enter price", step: "0.01"}))
+    render_inline(Flowbite::Input::Number.new(form: @form, attribute: :price, input_options: {placeholder: "Enter price", step: "0.01"}))
 
     assert_selector("input[name='product[price]'][placeholder='Enter price'][step='0.01']")
   end

--- a/test/components/input/password_test.rb
+++ b/test/components/input/password_test.rb
@@ -49,7 +49,7 @@ class Flowbite::Input::PasswordTest < Minitest::Test
   end
 
   def test_adds_attributes_to_input
-    render_inline(Flowbite::Input::Password.new(form: @form, attribute: :password, input_attributes: {placeholder: "Enter password"}))
+    render_inline(Flowbite::Input::Password.new(form: @form, attribute: :password, input_options: {placeholder: "Enter password"}))
 
     assert_selector("input[name='user[password]'][placeholder='Enter password']")
   end

--- a/test/components/input/phone_test.rb
+++ b/test/components/input/phone_test.rb
@@ -49,7 +49,7 @@ class Flowbite::Input::PhoneTest < Minitest::Test
   end
 
   def test_adds_attributes_to_input
-    render_inline(Flowbite::Input::Phone.new(form: @form, attribute: :phone, input_attributes: {placeholder: "Enter phone number"}))
+    render_inline(Flowbite::Input::Phone.new(form: @form, attribute: :phone, input_options: {placeholder: "Enter phone number"}))
 
     assert_selector("input[name='user[phone]'][placeholder='Enter phone number']")
   end

--- a/test/components/input/select_test.rb
+++ b/test/components/input/select_test.rb
@@ -64,7 +64,7 @@ class Flowbite::Input::SelectTest < Minitest::Test
   end
 
   def test_adds_attributes_to_input
-    render_inline(Flowbite::Input::Select.new(form: @form, attribute: :category_id, collection: @categories.map { |c| [c.name, c.id] }, input_attributes: {"data-controller": "interactive"}))
+    render_inline(Flowbite::Input::Select.new(form: @form, attribute: :category_id, collection: @categories.map { |c| [c.name, c.id] }, input_options: {"data-controller": "interactive"}))
 
     assert_selector("select[name='article[category_id]'][data-controller='interactive']")
   end

--- a/test/components/input/textarea_test.rb
+++ b/test/components/input/textarea_test.rb
@@ -49,7 +49,7 @@ class Flowbite::Input::TextareaTest < Minitest::Test
   end
 
   def test_adds_attributes_to_textarea
-    render_inline(Flowbite::Input::Textarea.new(form: @form, attribute: :content, input_attributes: {placeholder: "Enter article content", rows: 10}))
+    render_inline(Flowbite::Input::Textarea.new(form: @form, attribute: :content, input_options: {placeholder: "Enter article content", rows: 10}))
 
     assert_selector("textarea[name='article[content]'][placeholder='Enter article content'][rows='10']")
   end

--- a/test/components/input_field/checkbox_test.rb
+++ b/test/components/input_field/checkbox_test.rb
@@ -50,8 +50,8 @@ class Flowbite::InputField::CheckboxTest < Minitest::Test
     assert_selector("p#user_subscribed_hint", text: "Check to receive updates")
   end
 
-  def test_passes_input_attributes_to_input_element
-    render_inline(Flowbite::InputField::Checkbox.new(form: @form, attribute: :subscribed, input_attributes: {"data-controller": "checkbox"}))
+  def test_passes_input_options_to_input_element
+    render_inline(Flowbite::InputField::Checkbox.new(form: @form, attribute: :subscribed, input_options: {"data-controller": "checkbox"}))
 
     assert_selector("input[type='checkbox'][data-controller='checkbox']")
   end

--- a/test/components/input_field/password_test.rb
+++ b/test/components/input_field/password_test.rb
@@ -37,8 +37,8 @@ class Flowbite::InputField::PasswordTest < Minitest::Test
     assert_selector("p#user_password_hint", text: "Enter a secure password")
   end
 
-  def test_passes_input_attributes_to_input_element
-    render_inline(Flowbite::InputField::Password.new(form: @form, attribute: :password, input_attributes: {placeholder: "Enter password"}))
+  def test_passes_input_options_to_input_element
+    render_inline(Flowbite::InputField::Password.new(form: @form, attribute: :password, input_options: {placeholder: "Enter password"}))
 
     assert_selector("input[type='password'][placeholder='Enter password']")
   end


### PR DESCRIPTION
This matches the naming convention used in ActionView helpers better; nowhere are they called "attributes".