### PR TITLE
`input_options` -> `input`

### DIFF
--- a/app/components/flowbite/input/field.rb
+++ b/app/components/flowbite/input/field.rb
@@ -61,7 +61,7 @@ module Flowbite
         @attribute = attribute
         @disabled = disabled
         @form = form
-        @input_options = input_options
+        @input_options = input_options || {}
         @object = form.object
         @size = size
       end

--- a/app/components/flowbite/input/select.rb
+++ b/app/components/flowbite/input/select.rb
@@ -42,7 +42,7 @@ module Flowbite
         {
           class: classes,
           disabled: disabled?
-        }.merge(@input_options)
+        }.merge(input_options)
       end
 
       # Returns the options argument for the select method

--- a/app/components/flowbite/input_field.rb
+++ b/app/components/flowbite/input_field.rb
@@ -70,12 +70,12 @@ module Flowbite
       @object.errors[@attribute] || []
     end
 
-    def initialize(attribute:, form:, disabled: false, hint: nil, input_options: {}, label: {}, size: :default)
+    def initialize(attribute:, form:, disabled: false, hint: nil, input: {}, label: {}, size: :default)
       @attribute = attribute
       @disabled = disabled
       @form = form
       @hint = hint
-      @input_options = input_options
+      @input = input
       @label = label
       @object = form.object
       @size = size
@@ -119,7 +119,7 @@ module Flowbite
         form: @form,
         attribute: @attribute,
         disabled: @disabled,
-        input_options: default_input_options.merge(@input_options),
+        input_options: input_options,
         size: @size
       ))
     end
@@ -153,6 +153,10 @@ module Flowbite
 
     def id_for_hint_element
       "#{@form.object_name}_#{@attribute}_hint"
+    end
+
+    def input_options
+      default_input_options.merge(@input[:input_options] || {})
     end
   end
 end

--- a/app/components/flowbite/input_field/select.rb
+++ b/app/components/flowbite/input_field/select.rb
@@ -3,8 +3,8 @@
 module Flowbite
   class InputField
     class Select < InputField
-      def initialize(attribute:, form:, collection: [], disabled: false, hint: nil, input_options: {}, size: :default)
-        super(attribute: attribute, disabled: disabled, form: form, hint: hint, input_options: input_options, size: size)
+      def initialize(attribute:, form:, collection: [], disabled: false, hint: nil, input: {}, size: :default)
+        super(attribute: attribute, disabled: disabled, form: form, hint: hint, input: input, size: size)
         @collection = collection
       end
 
@@ -15,7 +15,7 @@ module Flowbite
             collection: @collection,
             disabled: @disabled,
             form: @form,
-            input_options: @input_options,
+            input_options: input_options,
             size: @size
           )
         )

--- a/test/components/flowbite/input_field_test.rb
+++ b/test/components/flowbite/input_field_test.rb
@@ -86,7 +86,7 @@ class Flowbite::InputFieldTest < Minitest::Test
   end
 
   def test_passes_input_options_to_input_element
-    render_inline(Flowbite::InputField.new(form: @form, attribute: :title, input_options: {placeholder: "Enter title"}))
+    render_inline(Flowbite::InputField.new(form: @form, attribute: :title, input: {input_options: {placeholder: "Enter title"}}))
 
     assert_component_rendered
     assert_selector("input[type='text'][placeholder='Enter title']")
@@ -99,7 +99,7 @@ class Flowbite::InputFieldTest < Minitest::Test
   end
 
   def test_passes_input_options_to_select_element
-    render_inline(Flowbite::InputField::Select.new(form: @form, attribute: :state, collection: ["read", "unread"], input_options: {"data-key": "state-select"}))
+    render_inline(Flowbite::InputField::Select.new(form: @form, attribute: :state, collection: ["read", "unread"], input: {input_options: {"data-key": "state-select"}}))
 
     assert_selector("select[data-key='state-select']")
   end

--- a/test/components/input/field_test.rb
+++ b/test/components/input/field_test.rb
@@ -60,4 +60,9 @@ class Flowbite::Input::FieldTest < Minitest::Test
     assert_component_rendered
     assert_selector("input[name='book[title]'][placeholder='Enter title']")
   end
+
+  def test_defaults_input_options_to_a_hash
+    component = Flowbite::Input::Field.new(form: @form, attribute: :title)
+    assert_equal({}, component.input_options)
+  end
 end

--- a/test/components/input_field/checkbox_test.rb
+++ b/test/components/input_field/checkbox_test.rb
@@ -51,7 +51,7 @@ class Flowbite::InputField::CheckboxTest < Minitest::Test
   end
 
   def test_passes_input_options_to_input_element
-    render_inline(Flowbite::InputField::Checkbox.new(form: @form, attribute: :subscribed, input_options: {"data-controller": "checkbox"}))
+    render_inline(Flowbite::InputField::Checkbox.new(form: @form, attribute: :subscribed, input: {input_options: {"data-controller": "checkbox"}}))
 
     assert_selector("input[type='checkbox'][data-controller='checkbox']")
   end

--- a/test/components/input_field/password_test.rb
+++ b/test/components/input_field/password_test.rb
@@ -38,7 +38,7 @@ class Flowbite::InputField::PasswordTest < Minitest::Test
   end
 
   def test_passes_input_options_to_input_element
-    render_inline(Flowbite::InputField::Password.new(form: @form, attribute: :password, input_options: {placeholder: "Enter password"}))
+    render_inline(Flowbite::InputField::Password.new(form: @form, attribute: :password, input: {input_options: {placeholder: "Enter password"}}))
 
     assert_selector("input[type='password'][placeholder='Enter password']")
   end


### PR DESCRIPTION
All default `input` elements can be customized using the `:input` argument, similar to how default `label` elements can be customized using the `:label` argument.

Everything in `input[:input_options]` will be passed directly to the input component, usually ending up as HTML attributes on the input.